### PR TITLE
Fix GridLayoutManager column reversal when scrolling up/left

### DIFF
--- a/library/src/main/java/com/antonioleiva/recyclerviewextensions/GridLayoutManager.java
+++ b/library/src/main/java/com/antonioleiva/recyclerviewextensions/GridLayoutManager.java
@@ -94,13 +94,14 @@ public class GridLayoutManager extends BaseLayoutManager {
                     bottom = renderState.mOffset + consumed;
                 }
             } else {
-                top = columnCount * itemWidth + getPaddingTop();
-                bottom = top + mOrientationHelper.getDecoratedMeasurementInOther(view);
-
                 if (renderState.mLayoutDirection == RenderState.LAYOUT_START) {
+                    bottom = getHeight() - getPaddingBottom() - itemWidth * columnCount;
+                    top = bottom - mOrientationHelper.getDecoratedMeasurementInOther(view);
                     right = renderState.mOffset;
                     left = renderState.mOffset - consumed;
                 } else {
+                    top = columnCount * itemWidth + getPaddingTop();
+                    bottom = top + mOrientationHelper.getDecoratedMeasurementInOther(view);
                     left = renderState.mOffset;
                     right = renderState.mOffset + consumed;
                 }


### PR DESCRIPTION
If you scrolled far enough to unload a column and reversed your scroll direction, the columns would become reversed, i.e.

Before:

> **1 2 3**
> 4 5 6
> 7 8 9

After:

> **3 2 1**
> 4 5 6
> 7 8 9
