### PR TITLE
change old api's use

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,19 +1,19 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 'android-L'
-    buildToolsVersion "19.1.0"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "com.antonioleiva.recyclerviewextensions.app"
-        minSdkVersion 'L'
-        targetSdkVersion 'L'
+        minSdkVersion 14
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
@@ -21,8 +21,8 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:recyclerview-v7:21.+'
-    compile 'com.squareup.picasso:picasso:2.+'
-    compile 'com.android.support:palette-v7:21.+'
+    compile 'com.android.support:recyclerview-v7:23.4.0'
+    compile 'com.squareup.picasso:picasso:2.5.2'
+    compile 'com.android.support:palette-v7:23.4.0'
     compile project(':library')
 }

--- a/app/src/main/java/com/antonioleiva/recyclerviewextensions/example/MainActivity.java
+++ b/app/src/main/java/com/antonioleiva/recyclerviewextensions/example/MainActivity.java
@@ -3,12 +3,12 @@ package com.antonioleiva.recyclerviewextensions.example;
 import android.app.Activity;
 import android.os.Bundle;
 import android.support.v7.widget.DefaultItemAnimator;
+import android.support.v7.widget.GridLayoutManager;
+import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-
-import com.antonioleiva.recyclerviewextensions.GridLayoutManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,18 +26,20 @@ public class MainActivity extends Activity {
         recyclerView.setHasFixedSize(true);
         final MyRecyclerAdapter adapter;
         recyclerView.setAdapter(adapter = new MyRecyclerAdapter(createMockList(), R.layout.item));
-        recyclerView.setLayoutManager(new GridLayoutManager(this));
+        LinearLayoutManager linearLayoutManager = new GridLayoutManager(this, 2);
+        recyclerView.setLayoutManager(linearLayoutManager);
         recyclerView.setItemAnimator(new DefaultItemAnimator());
 
         adapter.setOnItemClickListener(new OnRecyclerViewItemClickListener<ViewModel>() {
-            @Override public void onItemClick(View view, ViewModel viewModel) {
+            @Override
+            public void onItemClick(View view, ViewModel viewModel) {
                 adapter.remove(viewModel);
             }
         });
     }
 
     private List<ViewModel> createMockList() {
-        List<ViewModel> items = new ArrayList<ViewModel>();
+        List<ViewModel> items = new ArrayList<>();
         for (int i = 0; i < 20; i++) {
             items.add(new ViewModel(i, "Item " + (i + 1), MOCK_URL + (i % 10 + 1)));
         }
@@ -58,9 +60,6 @@ public class MainActivity extends Activity {
         // automatically handle clicks on the Home/Up button, so long
         // as you specify a parent activity in AndroidManifest.xml.
         int id = item.getItemId();
-        if (id == R.id.action_settings) {
-            return true;
-        }
-        return super.onOptionsItemSelected(item);
+        return id == R.id.action_settings || super.onOptionsItemSelected(item);
     }
 }

--- a/app/src/main/java/com/antonioleiva/recyclerviewextensions/example/MyRecyclerAdapter.java
+++ b/app/src/main/java/com/antonioleiva/recyclerviewextensions/example/MyRecyclerAdapter.java
@@ -92,9 +92,9 @@ public class MyRecyclerAdapter extends RecyclerView.Adapter<MyRecyclerAdapter.Vi
             paletteManager.getPalette(key, bitmap, new PaletteManager.Callback() {
                 @Override
                 public void onPaletteReady(Palette palette) {
-                    int bgColor = palette.getDarkVibrantColor().getRgb();
+                    int bgColor = palette.getDarkVibrantColor(0x7DD1FF);
                     text.setBackgroundColor(setColorAlpha(bgColor, 192));
-                    text.setTextColor(palette.getLightMutedColor().getRgb());
+                    text.setTextColor(palette.getLightMutedColor(0x7DD1FF));
                 }
             });
         }

--- a/app/src/main/java/com/antonioleiva/recyclerviewextensions/example/OnRecyclerViewItemClickListener.java
+++ b/app/src/main/java/com/antonioleiva/recyclerviewextensions/example/OnRecyclerViewItemClickListener.java
@@ -3,5 +3,5 @@ package com.antonioleiva.recyclerviewextensions.example;
 import android.view.View;
 
 public interface OnRecyclerViewItemClickListener<Model> {
-    public void onItemClick(View view, Model model);
+    void onItemClick(View view, Model model);
 }

--- a/app/src/main/java/com/antonioleiva/recyclerviewextensions/example/PaletteManager.java
+++ b/app/src/main/java/com/antonioleiva/recyclerviewextensions/example/PaletteManager.java
@@ -5,7 +5,7 @@ import android.support.v7.graphics.Palette;
 import android.util.LruCache;
 
 public class PaletteManager {
-    private LruCache<String, Palette> cache = new LruCache<String, Palette>(100);
+    private LruCache<String, Palette> cache = new LruCache<>(100);
 
     public interface Callback {
         void onPaletteReady(Palette palette);
@@ -16,7 +16,14 @@ public class PaletteManager {
         if (palette != null)
             callback.onPaletteReady(palette);
         else
-            Palette.generateAsync(bitmap, 24, new Palette.PaletteAsyncListener() {
+//            Palette.generateAsync(bitmap, 24, new Palette.PaletteAsyncListener() {
+//                @Override
+//                public void onGenerated(Palette palette) {
+//                    cache.put(key, palette);
+//                    callback.onPaletteReady(palette);
+//                }
+//            }
+            new Palette.Builder(bitmap).generate(new Palette.PaletteAsyncListener() {
                 @Override
                 public void onGenerated(Palette palette) {
                     cache.put(key, palette);

--- a/app/src/main/java/com/antonioleiva/recyclerviewextensions/example/PaletteManager.java
+++ b/app/src/main/java/com/antonioleiva/recyclerviewextensions/example/PaletteManager.java
@@ -16,13 +16,6 @@ public class PaletteManager {
         if (palette != null)
             callback.onPaletteReady(palette);
         else
-//            Palette.generateAsync(bitmap, 24, new Palette.PaletteAsyncListener() {
-//                @Override
-//                public void onGenerated(Palette palette) {
-//                    cache.put(key, palette);
-//                    callback.onPaletteReady(palette);
-//                }
-//            }
             new Palette.Builder(bitmap).generate(new Palette.PaletteAsyncListener() {
                 @Override
                 public void onGenerated(Palette palette) {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.+'
+        classpath 'com.android.tools.build:gradle:2.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/library/.gitignore
+++ b/library/.gitignore
@@ -14,8 +14,6 @@ gen/
 
 # Gradle files
 .gradle/
-./gradlew.bat
-./gradlew
 build/
 mirror/
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,19 +1,18 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "19.1.0"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
-        applicationId "com.antonioleiva.recyclerviewextensions"
-        minSdkVersion 'L'
-        targetSdkVersion 'L'
+        minSdkVersion 14
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
@@ -21,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:recyclerview-v7:21.+'
+    compile 'com.android.support:recyclerview-v7:23.4.0'
 }


### PR DESCRIPTION
Now, there is GridLayoutManager in android.support.v7.widget.So we can use the GridLayoutManager in android.support.v7.widget.
And the Palette.generateAsync is Deprecated.We can use Palette.Builder(bitmap).generate to replace that.